### PR TITLE
sort files on directory loader

### DIFF
--- a/lib/loaders/common/directory.js
+++ b/lib/loaders/common/directory.js
@@ -18,6 +18,8 @@ module.exports = require("../base").extend({
 			return [dir, file].join("/");
 		});
 
+		files.sort();
+
 		self._loaders.getLoader(files).load(next);
 	}
 });


### PR DESCRIPTION
Different SO filesystem/OS/etc give different results on "readdir":

https://groups.google.com/forum/#!topic/nodejs/j7P8kCcv15g


And celeri needs the plugins to be loaded in order "argv" first and then "helper", otherwise it fails with this error:

```
TypeError: Object #<Object> has no method 'option'
    at Object.exports.plugin (app/nsp/node_modules/celeri/lib/plugins/help.js:174:9)
    at Function.structr.load.on.s.self.collection.exports.(anonymous function).self.module (app/nsp/node_modules/celeri/node_modules/plugin/lib/collections/plugins.js:71:37)
    at Function.runFn (app/nsp/node_modules/celeri/node_modules/outcome/lib/index.js:16:24)
    at Function.fn (app/nsp/node_modules/celeri/node_modules/outcome/lib/index.js:50:12)
    at next (app/nsp/node_modules/celeri/node_modules/plugin/node_modules/step/lib/step.js:51:23)
    at _asyncMap (app/nsp/node_modules/celeri/node_modules/plugin/node_modules/async/lib/async.js:190:13)
    at async.forEachSeries (app/nsp/node_modules/celeri/node_modules/plugin/node_modules/async/lib/async.js:104:20)
    at _asyncMap (app/nsp/node_modules/celeri/node_modules/plugin/node_modules/async/lib/async.js:184:9)
    at Object.doSeries [as mapSeries] (app/nsp/node_modules/celeri/node_modules/plugin/node_modules/async/lib/async.js:174:23)
    at module.exports.structr.loadDeps (app/nsp/node_modules/celeri/node_modules/plugin/lib/collections/plugins.js:170:9)
```
